### PR TITLE
Bake built-in variables

### DIFF
--- a/addons/Theatre/classes/Dialogue.gd
+++ b/addons/Theatre/classes/Dialogue.gd
@@ -97,7 +97,7 @@ func get_word_count(variables : Dictionary = {}) -> int:
     return RegEx \
     .create_from_string(r"\w+") \
     .search_all(_strip(
-        variables.merged(TheatreStage._VARIABLES_BUILT_IN),
+        variables,
         true, true
     )).size()
 

--- a/addons/Theatre/classes/DialogueParser.gd
+++ b/addons/Theatre/classes/DialogueParser.gd
@@ -150,15 +150,19 @@ const TAG_DELAY_ALIASES : PackedStringArray = [
 const TAG_SPEED_ALIASES : PackedStringArray = [
     "SPEED", "SPD", "S"
 ]
-
 const VARS_BUILT_IN_KEYS : PackedStringArray = ["n", "spc", "eq"]
-const VAR_BUILT_IN_NEWLINE : String = "{n}"
 
 const BUILT_IN_TAGS : PackedStringArray = (
     TAG_DELAY_ALIASES +
     TAG_SPEED_ALIASES +
     VARS_BUILT_IN_KEYS
 )
+
+const VARS_BUILT_IN : Dictionary[String, String] = {
+    "n" : "\n",
+    "spc" : " ",
+    "eq" : "=",
+}
 
 const BB_ALIASES := {
     "bg": "bgcolor",
@@ -372,12 +376,15 @@ func _init(src : String = "", src_path : String = ""):
 
             # Dialogue text body
             else:
+                # Bake built-in variables
+                current_processed_string = current_processed_string.format(VARS_BUILT_IN)
+
                 if newline_stack > 0:
                     newline_stack += 1
                 var dlg_body := NEWLINE.repeat(newline_stack)\
                     + current_processed_string\
                     + (
-                        EMPTY if current_processed_string.ends_with(VAR_BUILT_IN_NEWLINE)
+                        EMPTY if current_processed_string.ends_with(NEWLINE)
                         else SPACE
                     )
                 newline_stack = 0
@@ -582,8 +589,7 @@ static func parse_tags(string : String) -> Dictionary:
         elif tag_key_l not in vars:
             vars.append(tag_key_l)
 
-        if tag_key_l not in VARS_BUILT_IN_KEYS:
-            string = string.replace(string_match, EMPTY)
+        string = string.replace(string_match, EMPTY)
 
         tag_pos_offset += string_match.length()
 

--- a/addons/Theatre/classes/TheatreStage.gd
+++ b/addons/Theatre/classes/TheatreStage.gd
@@ -109,7 +109,6 @@ func _set_variables(new_var : Dictionary) -> void:
 func _update_variables_dialogue() -> void:
     _variables_all.clear()
     _variables_all.merge(variables, true)
-    _variables_all.merge(_VARIABLES_BUILT_IN, true)
     if current_dialogue != null:
         var stepn := clampi(_step, 0, current_dialogue._sets.size())
         # NOTE, BUG: NOT COMPATIBLE WHEN CHANGING VARIABLE REAL-TIME
@@ -124,11 +123,6 @@ func _update_variables_dialogue() -> void:
             if dialogue_label != null:
                 dialogue_label.rerender()
 
-const _VARIABLES_BUILT_IN : Dictionary = {
-    "n" : "\n",
-    "spc" : " ",
-    "eq" : "=",
-}
 var _variables_all : Dictionary = {}
 
 ## Set a variable used in the written [Dialogue].


### PR DESCRIPTION
Built-in variables are now baked/hardcoded/embedded directly in parsing.

The built-in variables definition also now have been moved to `DialogueParser` from `TheatreStage`.
Also improve runtime performance, since less operations involving the built-in vars dictionary.

Resolves #51, resolves #50 